### PR TITLE
Proofreading for the v0.3 release

### DIFF
--- a/includes/header-paper.ily
+++ b/includes/header-paper.ily
@@ -4,7 +4,7 @@
 #(set-global-staff-size 18)
 
 \header {
-  title = "Twelve Etudes"
+  title = "Two Nocturnes"
   composer = "Frédéric Chopin (1810-1849)"
   opus = "Opus 62"
   maintainer = "Knute Snortum"

--- a/includes/nocturnes-op62-no1-parts.ily
+++ b/includes/nocturnes-op62-no1-parts.ily
@@ -5,7 +5,7 @@
 
 %%% Positions and shapes %%%
 
-slurShapeA = \shape #'((-17 . -8) (-13 . -3) (-2 . 1) (0 . 0)) \etc
+slurShapeA = \shape #'((-16.75 . -8) (-13 . -3) (-2 . 1) (0 . 0)) \etc
 slurShapeB = \shape #'((0 . 0) (0 . 0) (0 . 0) (0 . 1.25)) \etc
 slurShapeC = \shape #'((0 . 0) (0 . 3) (0 . 3.25) (0 . 0)) \etc
 slurShapeD = \shape #'((0 . 0) (0 . 0.5) (0 . 1.5) (0 . 0)) \etc
@@ -69,7 +69,7 @@ rightHandUpper = \relative {
   <e fs cs'>1) |
   r2 \voiceOne b'8( as gs fs |
   ds'4\arpeggio cs8 b) b( as \grace { \moveStaffArpeggioA as\arpeggio } gs fs |
-  fs'4 fs \oneVoice <a, fs'> <e gs e'>8 <fs ds'> |
+  fs'4\arpeggio fs \oneVoice <a, fs'> <e gs e'>8 <fs ds'> |
   \voiceOne ds'8 cs e8. ds16  ds4\arpeggio cs8. b16 |
   b8 as gs fs) <fs ds'>4(\arpeggio cs'8 b |
   b8 as \tuplet 3/2 { as8 gs fs) } \grace { \once \hideNotes fs'4\arpeggio } 
@@ -236,7 +236,7 @@ rightHandLower = \relative {
   s1 * 2 |
   \voiceTwo
   ds'4\arpeggio ds e \grace { \once \hideNotes e8\arpeggio } e4 |
-  <ds a'>2 s |
+  <ds a'>2\arpeggio s |
   gs4. gs8 
     << 
       { 
@@ -403,7 +403,7 @@ leftHandUpper = \relative {
   \barNumberCheck 73
   s4. b2 s8 |
   s1 |
-  d4( c4 s8 b4 b8 |
+  d4( c4. b4 b8 |
   \oneVoice fs8) s8 s4 s2 |
   s1 * 2 |
   \voiceThree s8 b4 cs8 ds gs,4 s8 |
@@ -445,10 +445,10 @@ leftHandLower = \relative {
   ds,8( ds' fss ds)  gs,( ds' gs es) |
   ds,8( ds' fs ds)  ds,( ds' gs ds) |
   \oneVoice ds,8 as''4-> as8 \moveRestA as\rest as4 as8 |
-  \moveRestA as\rest as4 as8 \moveRestA as\rest as4 as8 |
+  \moveRestA as\rest as4 as8 \moveRestA as\rest b4 b8 |
   \moveRestA as\rest as4-> as8 \moveRestA as\rest as4 as8 |
-  \moveRestA as\rest as4 as8 \moveRestA as\rest as4 as8 |
-  \moveRestA as\rest as4 as8 \moveRestA as\rest as4 as8 |
+  \moveRestA as\rest as4 as8 \moveRestA as\rest b4 b8 |
+  \moveRestA as\rest as4 as8 \moveRestA as\rest b4 b8 |
     
   \barNumberCheck 25
   \moveRestA as\rest as4-> as8 \voiceFour <b, gs'>2 |
@@ -495,7 +495,7 @@ leftHandLower = \relative {
   
   \barNumberCheck 57
   af,8( <ef' af c>4 q8) r c,4( df8 |
-  ef8) <ef' af c>4\slurPositionsE ( q8 <ef g df'>8 ef4->) ef8\slurShapeC ( |
+  ef8) <ef' af c>4\slurPositionsE ( <f af c>8 <ef g df'>8 ef4->) ef8\slurShapeC ( |
   ef8 ef4-> f8 ef ef4-> ef8) |
   ef,8(\< bf' g' cf bf g ef'4)\! |
   ef,,8(\< af f' bf af f <df' af'>4)\! |

--- a/includes/nocturnes-op62-no2-parts.ily
+++ b/includes/nocturnes-op62-no2-parts.ily
@@ -162,7 +162,7 @@ rightHandUpper = \relative {
   <cs, a'>8 <b gs'>) \oneVoice r4 r16 cs^( e ds s16 \voiceOne 
     e8.*1/3 \noBeam e'16. e32 |
   e4  fs16 e cs gs  gs4  fs16 e fs gs |
-  gs4. as16 gs <ds fs>4. <cs e>8 |
+  \grace { \once \hideNotes gs8\arpeggio } gs4. as16 gs <ds fs>4. <cs e>8 |
   <a c fs>4 <b es gs> a' <a, ds>16 cs'8 ds,16) |
   <gs, ds'~>4\arpeggio \voiceOne ds'16( \staffDown b \staffUp e fs  
     \oneVoice a gs cs b  e fs gs b |
@@ -203,7 +203,10 @@ rightHandLower = \relative {
   r16 <b ds>8 q16 r <cs ds>8 q16 r <b ds>8 <cs ds> <b ds> <cs ds>16 |
   r16 <b ds>8 <b cs> <a cs> <b cs>16 r <a cs>8 <b cs> <a cs> a16 |
   s4 s16 a8 s16 s4 s16 a8 s16 |
-  s1 |
+  s2. s8.
+  % This is an enharmonic tie from B-sharp in rightHandUpper to C-natural in
+  % the following measure.
+  \once \hideNotes bs16~ |
   
   \barNumberCheck 49
   c16 \staffDown \voiceOne <g c>8 q <a c> c16  a a8 a <a b> <a ds>16 |
@@ -228,7 +231,7 @@ rightHandLower = \relative {
   fs'2 s4 ds |
   e4 s2 fs16 e gs8 |
   <e gs>2  bs16 cs e ds  cs8.. b32 |
-  e2 s |
+  \grace { \once \hideNotes e8\arpeggio } e2 s |
   s2  e16 f c e  s4 |
   s4 ds8[ e16] s s2 |
   s1 |
@@ -435,7 +438,9 @@ dynamics = {
   \partial 4 s4^\sostenutoWhiteout
   s1 * 2 |
   s2..\< s8\! |
-  s1 * 4 |
+  s2. s4\> |
+  s4 s\! s2 |
+  s1 * 2 |
   s2 s8.\< s16\! s4 |
   
   \barNumberCheck 9


### PR DESCRIPTION
I used the IMSLP edition listed as the `source` as the reference for proofreading. Mostly I focused on note discrepancies, as I did for your Op.25 edition, but there were a couple arpeggio marks to attend to, and I noticed a missing hairpin as well.

I began looking at the pedal markings and slurs, but I'll wait until I can do a more thorough sweep before suggesting any changes there.